### PR TITLE
Import collections.mutableset from the proper place

### DIFF
--- a/OrderedSet.py
+++ b/OrderedSet.py
@@ -1,6 +1,6 @@
 import collections
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
   '''
   http://code.activestate.com/recipes/576694-orderedset/
   '''


### PR DESCRIPTION
Fixes #1 to address changes made in Python 3.3 by importing `MutableSet` from `collections.abc` rather than `collections`.  Breaks compatibility with python 3.1 and 3.2, adds compatibility for Python 3.10 and newer.